### PR TITLE
Dockerised the test site

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,25 @@ Welcome to the ECSD Tech Test
 
 
 ## Running the application
+
+### Docker Version
+You will need to have [docker] installed and running to start the site.
+
+- Run `docker run -it --rm <IMAGE NAME TBC>` to start the app
+- Visit `localhost` in a browser
+
+OR
+
+- Clone this repository and switch to the `docker` directory
+- Run `./build.sh && ./run.sh`
+- Visit `localhost` in a browser
+
+### Local Version
 You will need to have [node] and [yarn] both installed on your machine to run the app.
 
-
-From the terminal run `yarn && yarn start` to start the app
+- Clone this repository and make sure you are in this directory (the one containing `README.md`!)
+- Run `yarn && yarn start` to start the app
+- Visit `localhost:3000` in a browser
 
 ## Challenge 
 Once the app is started follow the instructions on the screen

--- a/docker/.dockerprep.cfg
+++ b/docker/.dockerprep.cfg
@@ -1,0 +1,2 @@
+# Original command: (Use this to recreate the original structure of this directory)
+#  dockerprep node:9.11.1 ecsd-tech-test 0.0.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:9.11.1
+
+WORKDIR /
+RUN git clone 'https://github.com/L0wry/custom-tech-test.git' \
+ && mv 'custom-tech-test' 'tech-test'
+WORKDIR /tech-test
+RUN yarn
+
+ENTRYPOINT yarn start

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,4 @@
+. project.cfg
+
+docker build --tag "$repo:latest" . && \
+docker tag "$repo:latest" "$repo:$tag"

--- a/docker/debug.sh
+++ b/docker/debug.sh
@@ -1,0 +1,23 @@
+. project.cfg
+
+debug_name="debug-$name"
+docker stop "$debug_name" > /dev/null 2>&1
+docker rm "$debug_name" > /dev/null 2>&1
+
+docker run -it \
+  --name="$debug_name" \
+  --entrypoint='' \
+  "$repo":latest \
+  sh
+
+# Some "docker run" options for quick reference:
+#  --env VARIABLE=value
+#  --publish, -p HOST_PORT:CONTAINER_PORT
+#  --volume=[HOST_PATH|NAMED_VOLUME]:DEST_PATH[:ro]
+#  --mount type=bind,source=HOST_PATH,destination=DEST_PATH[,readonly]
+#  --mount type=volume[,source=NAMED_VOLUME],destination=DEST_PATH[,readonly]
+#  --mount type=tmpfs,destination=DEST_PATH
+#
+# NB:
+#  - Volume will create DEST_PATH if it doesn't already exist
+#  - Mount and Volume require absolute paths

--- a/docker/project.cfg
+++ b/docker/project.cfg
@@ -1,0 +1,7 @@
+repo="ecsd-tech-test"
+tag="0.0.0"
+name="ecsd-tech-test"
+
+# NB: 
+#  - Command substitution can be used in variables here - try to use "$(this format)" instead of `backticks` if possible
+#  - Mount/Volume paths used here MUST be absolute - use eg. "$(realpath SYMLINK_PATH)" if you don't want to hardcode them

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,18 @@
+. project.cfg
+
+docker run --rm -d \
+  --name="$name" \
+  --publish 80:3000 \
+  "$repo":latest
+
+# Some "docker run" options for quick reference:
+#  --env VARIABLE=value
+#  --publish, -p HOST_PORT:CONTAINER_PORT
+#  --volume=[HOST_PATH|NAMED_VOLUME]:DEST_PATH[:ro]
+#  --mount type=bind,source=HOST_PATH,destination=DEST_PATH[,readonly]
+#  --mount type=volume[,source=NAMED_VOLUME],destination=DEST_PATH[,readonly]
+#  --mount type=tmpfs,destination=DEST_PATH
+#
+# NB:
+#  - Volume will create DEST_PATH if it doesn't already exist
+#  - Mount and Volume require absolute paths


### PR DESCRIPTION
`./run.sh` will run the test site so you can access it locally on port 80 (hit `localhost` or `127.1` in a browser). Readme updated to explain.

This should avoid people having any issues with node/yarn or the test itself, allowing them to concentrate on giving a good solution - they should be able to write code in their own environment just the same as before, albeit hitting `:80` instead of `:3000`, and they can even put their code in the same place for the CI job :)